### PR TITLE
Made MaxPlayers and ViewDistance default to -1 and ignore when not changed

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -96,10 +96,12 @@ Parameters:
   MaxPlayers:
     Type: Number
     Description: Max number of players that can connect simultaneously (default 20)
+    Default: -1
 
   ViewDistance:
     Type: Number
     Description: Max view radius (in chunks) the server will send to the client (default 10)
+    Default: -1
 
   GameMode:
     Type: String
@@ -236,8 +238,8 @@ Conditions:
   SpotPriceProvided: !Not [ !Equals [ !Ref SpotPrice, '' ] ]
   MemoryProvided: !Not [ !Equals [ !Ref Memory, '' ] ]
   SeedProvided: !Not [ !Equals [ !Ref Seed, '' ] ]
-  MaxPlayersProvided: !Not [ !Equals [ !Ref MaxPlayers, '' ] ]
-  ViewDistanceProvided: !Not [ !Equals [ !Ref ViewDistance, '' ] ]
+  MaxPlayersProvided: !Not [ !Equals [ !Ref MaxPlayers, -1 ] ]
+  ViewDistanceProvided: !Not [ !Equals [ !Ref ViewDistance, -1 ] ]
   GameModeProvided: !Not [ !Equals [ !Ref GameMode, '' ] ]
   LevelTypeProvided: !Not [ !Equals [ !Ref LevelType, '' ] ]
   EnableRollingLogsProvided: !Not [ !Equals [ !Ref EnableRollingLogs, '' ] ]


### PR DESCRIPTION
See #14 .  My research suggests that there isn't a perfect, no-default-in-template, ignore-when-not-set solution for CloudFormation `Integer` types.

Two possible fixes:
- Set them to `Default: -1` then ignore that via a modified condition, which is what this PR does.
- Change to `String` type, perhaps with some integer-like regex validation.

Template looks a little strange on-render, as text says the defaults for these are 20/10, which they are when-absent in the launched image, and the env will be absent if these are left as `-1` per the template default, it's just a little odd-looking, but works.

With this change you can again click-through template to launch, without being forced to fill-in the defaults for these two parameters, which avoids setting the env for them in the container-launch, which also avoids missing a change in defaults there.

Fixes #14.