### PR TITLE
Added template parameters for ECS task EntryPoint and Command

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -25,6 +25,14 @@ Parameters:
     Description: "A t3.medium shouldn't cost more than a cent per hour. Note: Leave this blank to use on-demand pricing."
     Default: "0.05"
 
+  EntryPoint:
+    Type: CommaDelimitedList
+    Description: "Task entrypoint (Optional - image default is script /start)"
+
+  Command:
+    Type: CommaDelimitedList
+    Description: "Task command (Optional - image default is empty)"
+
   KeyPairName:
     Type: String
     Description: (Optional - An empty value disables this feature)
@@ -166,6 +174,11 @@ Metadata:
         - LevelType
         - EnableRollingLogs
         - Timezone
+      - Label:
+          default: Optional ECS Task Configuration
+        Parameters:
+        - EntryPoint
+        - Command
       - Label: 
           default: Optional Remote Access (SSH) Configuration
         Parameters:
@@ -196,6 +209,10 @@ Metadata:
         default: "A comma delimited list (no spaces) of player names"
       MinecraftVersion:
         default: "Minecraft version ie 1.16.3"
+      EntryPoint:
+        default: "Task/container --entrypoint, comma separated e.g. /bin/bash,-c"
+      Command:
+        default: "Task/container command, comma separated arguments passed to entrypoint"
       KeyPairName:
         default: "If you wish to access the instance via SSH, select a Key Pair to use. https://console.aws.amazon.com/ec2/v2/home?#KeyPairs:sort=keyName"
       YourIPv4:
@@ -229,6 +246,8 @@ Conditions:
   DifficultyProvided: !Not [ !Equals [ !Ref Difficulty, '' ] ]
   WhitelistProvided: !Not [ !Equals [ !Ref Whitelist, '' ] ]
   MinecraftVersionProvided: !Not [ !Equals [ !Ref MinecraftVersion, '' ] ]
+  EntryPointProvided: !Not [ !Equals [ !Join [ "", !Ref EntryPoint ], '' ] ]
+  CommandProvided: !Not [ !Equals [ !Join [ "", !Ref Command ], '' ] ]
   KeyPairNameProvided: !Not [ !Equals [ !Ref KeyPairName, '' ] ]
   IPv4AddressProvided: !Not [ !Equals [ !Ref YourIPv4, '' ] ]
   IPv6AddressProvided: !Not [ !Equals [ !Ref YourIPv6, '' ] ]
@@ -476,6 +495,14 @@ Resources:
         - Name: minecraft
           MemoryReservation: 1024
           Image: !Sub "itzg/minecraft-server:${MinecraftImageTag}"
+          EntryPoint: !If
+              - EntryPointProvided
+              - !Ref EntryPoint
+              - !Ref 'AWS::NoValue'
+          Command: !If
+              - CommandProvided
+              - !Ref Command
+              - !Ref 'AWS::NoValue'
           PortMappings:
           - ContainerPort: 25565
             HostPort: 25565


### PR DESCRIPTION
This allows overriding itzg/minecraft-server default EntryPoint (/start) and default
Command (empty) to customise launch with additional or custom commands, usually
finishing with: exec /start .

The template will accept either of these as comma-separated lists, e.g.:

- EntryPoint - `/bin/bash,-c`
- Command - `echo HelloWorld;exec /start`

When the default EntryPoint of `/start` is overridden, the script should always `exec` it to ensure it runs as PID 1.

Shout-out to @67shafar for advice on the template change.