### PR TITLE
Added an ASG Capacity Provider, linking the ASG with the ECS Service

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -288,7 +288,7 @@ Resources:
   SubnetA:
     Type: AWS::EC2::Subnet
     Properties:
-      AvailabilityZone: !Select 
+      AvailabilityZone: !Select
       - 0
       - !GetAZs 
         Ref: 'AWS::Region'
@@ -310,7 +310,7 @@ Resources:
   SubnetB:
     Type: AWS::EC2::Subnet
     Properties:
-      AvailabilityZone: !Select 
+      AvailabilityZone: !Select
       - 1
       - !GetAZs 
         Ref: 'AWS::Region'
@@ -435,8 +435,9 @@ Resources:
       AutoScalingGroupName: !Sub "${AWS::StackName}-asg"
       DesiredCapacity: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
       LaunchConfigurationName: !Ref LaunchConfiguration
-      MaxSize: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
-      MinSize: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
+      NewInstancesProtectedFromScaleIn: true
+      MaxSize: 1
+      MinSize: 0
       VPCZoneIdentifier:
         - !Ref SubnetA
         - !Ref SubnetB
@@ -475,6 +476,28 @@ Resources:
     Properties:
       ClusterName: !Sub "${AWS::StackName}-cluster"
 
+  ECSCapacityProvider:
+    Type: AWS::ECS::CapacityProvider
+    Properties:
+      AutoScalingGroupProvider:
+        AutoScalingGroupArn: !Ref AutoScalingGroup
+        ManagedScaling:
+          MaximumScalingStepSize: 1
+          MinimumScalingStepSize: 1
+          Status: ENABLED
+          TargetCapacity: 100
+        ManagedTerminationProtection: ENABLED
+
+  EcsClusterCapacityProviderAssociation:
+    Type: AWS::ECS::ClusterCapacityProviderAssociations
+    Properties:
+      Cluster: !Ref EcsCluster
+      CapacityProviders:
+        - !Ref ECSCapacityProvider
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: !Ref ECSCapacityProvider
+          Weight: 1
+
   EcsService:
     Type: AWS::ECS::Service
     Properties: 
@@ -482,6 +505,10 @@ Resources:
       DesiredCount: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
       ServiceName: !Sub "${AWS::StackName}-ecs-service"
       TaskDefinition: !Ref EcsTask  
+      CapacityProviderStrategy:
+        - CapacityProvider: !Ref ECSCapacityProvider
+          Weight: 1
+          Base: 0
       DeploymentConfiguration:
         MaximumPercent: 100
         MinimumHealthyPercent: 0


### PR DESCRIPTION
# Changes

- Adds an `AWS::ECS::CapacityProvider`, makes it the default capacity provider for the mc ECS Cluster, and makes it the capacity provider for the mc ECS Service.  See also note [1] below.
- ASG `MaxSize` and `MinSize` are now hard-set to 1/0 - these shouldn't need to change with Running/Stopped state, only the `DesiredCapacity` should change.

# Desired Outcome

- Existing `Running` / `Stopped` behaviour should remain unaltered.
- Now, if you should manually or auto-scale the mc ECS Service, the ASG should scale to match, with some delay.  So if Desired Tasks in the ECS Service transitions 1->0, the Capacity Provider's alarms and the ASG will after 15 minutes or so also scale from 1 to 0 instances running, so scale to zero cost.  If you later scale the ECS Service back 0->1 Desired, after a minute or so the Capacity Provider auto scale alarms will trigger the ASG to start an instance, and the pending task will deploy.

This isn't a huge benefit on its own, but it seems to deploy the ASG with the capacity provider as-designed.  It will also allow the scale of the ECS Service itself to control the ASG, which is currently running as capacity only, without scaling rules.

[1]: Originally I thought to only link the capacity provider to the cluster, and allow the service to pick it up by-default, which is what the documentation suggests should happen.  This was not working for me - I suspected a timing issue or need for an explicit `DependsOn` in the cf template - instead I elected to make the service/capacity-provider link explicit, which is probably better anyway.