### PR TITLE
Tighter route53 policy for DNS update support

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -455,14 +455,6 @@ Resources:
           - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
-      Policies:
-        - PolicyName: root
-          PolicyDocument: 
-            Version: "2012-10-17"
-            Statement: 
-              - Effect: "Allow"
-                Action: "route53:ChangeResourceRecordSets"
-                Resource: !Sub "arn:aws:route53:::hostedzone/${HostedZoneId}"
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile

--- a/cf.yml
+++ b/cf.yml
@@ -461,8 +461,8 @@ Resources:
             Version: "2012-10-17"
             Statement: 
               - Effect: "Allow"
-                Action: "route53:*"
-                Resource: "*"
+                Action: "route53:ChangeResourceRecordSets"
+                Resource: !Sub "arn:aws:route53:::hostedzone/${HostedZoneId}"
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -607,8 +607,8 @@ Resources:
             Version: "2012-10-17"
             Statement: 
               - Effect: "Allow"
-                Action: "route53:*"
-                Resource: "*"
+                Action: "route53:ChangeResourceRecordSets"
+                Resource: !Sub "arn:aws:route53:::hostedzone/${HostedZoneId}"
               - Effect: "Allow"
                 Action: "ec2:DescribeInstance*"
                 Resource: "*"


### PR DESCRIPTION
Two changes proposed in this PR:

- For the inline policy applied to `SetDNSRecordLambdaRole`, replace full access `route53:*` for `*` with `route53:ChangeResourceRecordSets` for `arn:aws:route53:::hostedzone/${HostedZoneId}`, which appears sufficient to update the `RecordName` in the `HostedZoneId`, when DNS update is configured.  Although we control the Lambda function content and actions, seems reasonable to restrict it to minimal privileges - can't touch other hosted zones or make other changes to the target zone.
- Removed, rather than applying the same change to, the same inline policy element in the ASG EC2 launch configuration `InstanceRole`.  This one needs a little more checking, as I couldn't figure why it is there, so it's possible that it could be needed by something I'm not aware of.  The DNS update occurs in the lambda targeted by the event processed by EventBridge, which assumes the required role and policy we grant it - the EC2 instance doesn't do anything directly - does it's role propagate anywhere?  I did the removal in a second commit in case it needs to be retained.  Note that this leaves `InstanceRole` without a custom policy and it could probably be removed, but I decided to retain it to make extension clearer - can remove if preferred.