### PR TITLE
Fixed possible loss of LaunchEvent DNS-update processing from first ASG launch

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -440,6 +440,8 @@ Resources:
       VPCZoneIdentifier:
         - !Ref SubnetA
         - !Ref SubnetB
+    Metadata:
+      LaunchEvent: !If [ DnsConfigEnabled, !GetAtt LaunchEvent.Arn, "" ]
 
   InstanceRole:
     Type: AWS::IAM::Role
@@ -666,7 +668,7 @@ Resources:
         - EC2 Instance Launch Successful
         detail:
           AutoScalingGroupName:
-          - !Ref AutoScalingGroup
+          - !Sub "${AWS::StackName}-asg"
       Name: !Sub "${AWS::StackName}-instance-launch"
       State: ENABLED
       Targets:


### PR DESCRIPTION
I've noticed that on a brand-new stack deployment with `DnsConfigEnabled`, DNS fails to update, with the launch event lost or unprocessed.

Prior to this PR,  `LaunchEvent` is depending on `AutoScalingGroup`, via the `AutoScalingGroupName: !Ref AutoScalingGroup` reference.  This forces CF to create the ASG first, and it starts launching an instance, before the `LaunchEvent` starts being created, and it can often happen that the instance launches successfully and fires the event before the `LaunchEvent` creation completes, and the event is lost and DNS is not updated.

This change reverses the dependency, by changing the `LaunchEvent`'s reference from an instance to a string with the same construction as in the ASG, and adds `Metadata` to the ASG, which decouples and reverses the ASG-first dependency.

To reverse the dependency, a `Metadata` is added to the ASG, referencing the `LaunchEvent`, when `DnsConfigEnabled`.  Note that a simple `DependsOn` is not possible, as this can't be done based on a condition, and DNS is optional, so `LaunchEvent` won't always exist and can't be depended-on directly.