### PR TITLE
Made NetworkMode: bridge explicit in ECS Task definition

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -493,6 +493,7 @@ Resources:
       - Host:
           SourcePath: /opt/minecraft
         Name: minecraft
+      NetworkMode: "bridge"
       ContainerDefinitions:      
         - Name: minecraft
           MemoryReservation: 1024


### PR DESCRIPTION
This is the default anyway, but relying on the default caused me some issues with other tooling that attempted to read
the NetworkMode from the TaskDefinition.  Can't hurt to set it explicitly as I think everyone is expecting bridge mode
here.