### PR TITLE
Update Python to 3.11

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -734,7 +734,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt SetDNSRecordLambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.11
       Timeout: 20
 
   LaunchEvent:


### PR DESCRIPTION
Updating Lambda Python version since AWS will deprecate 3.7 on Nov 23, 2023: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html