### PR TITLE
Replaced Launch Configuration with Launch Template

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 Description: Minecraft Spot Price Server via Docker / ECS
 
 Parameters:
@@ -9,37 +9,44 @@ Parameters:
 
   ServerState:
     Type: String
-    Description: "Running: A spot instance will launch shortly after setting this parameter; your Minecraft server should start within 5-10 minutes of changing this parameter (once UPDATE_IN_PROGRESS becomes UPDATE_COMPLETE). Stopped: Your spot instance (and thus Minecraft container) will be terminated shortly after setting this parameter."
+    Description: 'Running: A spot instance will launch shortly after setting this
+      parameter; your Minecraft server should start within 5-10 minutes of
+      changing this parameter (once UPDATE_IN_PROGRESS becomes UPDATE_COMPLETE).
+      Stopped: Your spot instance (and thus Minecraft container) will be
+      terminated shortly after setting this parameter.'
     Default: Running
-    AllowedValues: 
-    - Running
-    - Stopped
+    AllowedValues:
+      - Running
+      - Stopped
 
   InstanceType:
     Type: String
-    Description: "t3.medium is a good cost-effective instance, 2 vCPUs and 3.75 GB of RAM with moderate network performance. Change at your discretion. https://aws.amazon.com/ec2/instance-types/."
+    Description: t3.medium is a good cost-effective instance, 2 vCPUs and 3.75 GB of
+      RAM with moderate network performance. Change at your discretion.
+      https://aws.amazon.com/ec2/instance-types/.
     Default: t3.medium
 
   SpotPrice:
     Type: String
-    Description: "A t3.medium shouldn't cost much more than a cent per hour. Note: Leave this blank to use on-demand pricing."
-    Default: "0.05"
+    Description: 'A t3.medium shouldn''t cost much more than a cent per hour. Note:
+      Leave this blank to use on-demand pricing.'
+    Default: '0.05'
 
   ContainerInsights:
     Type: String
-    Description: "Enable/Disable ECS Container Insights for ECS Cluster"
+    Description: Enable/Disable ECS Container Insights for ECS Cluster
     Default: disabled
     AllowedValues:
-    - enabled
-    - disabled
+      - enabled
+      - disabled
 
   EntryPoint:
     Type: CommaDelimitedList
-    Description: "Task entrypoint (Optional - image default is script /start)"
+    Description: Task entrypoint (Optional - image default is script /start)
 
   Command:
     Type: CommaDelimitedList
-    Description: "Task command (Optional - image default is empty)"
+    Description: Task command (Optional - image default is empty)
 
   LogGroupName:
     Type: String
@@ -54,7 +61,7 @@ Parameters:
   LogStreamPrefix:
     Type: String
     Description: (Optional)
-    Default: 'minecraft-server'
+    Default: minecraft-server
 
   KeyPairName:
     Type: String
@@ -73,22 +80,31 @@ Parameters:
 
   HostedZoneId:
     Type: String
-    Description: (Optional - An empty value disables this feature) If you have a hosted zone in Route 53 and wish to set a DNS record whenever your Minecraft instance starts, supply the hosted zone ID here.
+    Description: (Optional - An empty value disables this feature) If you have a
+      hosted zone in Route 53 and wish to set a DNS record whenever your
+      Minecraft instance starts, supply the hosted zone ID here.
     Default: ''
 
   RecordName:
     Type: String
-    Description: (Optional - An empty value disables this feature) If you have a hosted zone in Route 53 and wish to set a DNS record whenever your Minecraft instance starts, supply the name of the record here (e.g. minecraft.mydomain.com).
+    Description: (Optional - An empty value disables this feature) If you have a
+      hosted zone in Route 53 and wish to set a DNS record whenever your
+      Minecraft instance starts, supply the name of the record here (e.g.
+      minecraft.mydomain.com).
     Default: ''
 
   MinecraftImageTag:
     Type: String
-    Description: "Java version (Examples include latest, adopt13, openj9, etc) Refer to tag descriptions available here: https://github.com/itzg/docker-minecraft-server)"
-    Default: 'latest'
+    Description: 'Java version (Examples include latest, adopt13, openj9, etc) Refer
+      to tag descriptions available here:
+      https://github.com/itzg/docker-minecraft-server)'
+    Default: latest
 
   MinecraftTypeTag:
     Type: String
-    Description: "(Examples include SPIGOT, BUKKIT, TUINITY, etc) Refer to tag descriptions available here: https://github.com/itzg/docker-minecraft-server)"
+    Description: '(Examples include SPIGOT, BUKKIT, TUINITY, etc) Refer to tag
+      descriptions available here:
+      https://github.com/itzg/docker-minecraft-server)'
 
   AdminPlayerNames:
     Type: String
@@ -97,13 +113,13 @@ Parameters:
 
   Difficulty:
     Type: String
-    Description: "The game's difficulty"
+    Description: The game's difficulty
     Default: normal
     AllowedValues:
-    - peaceful
-    - easy
-    - normal
-    - hard
+      - peaceful
+      - easy
+      - normal
+      - hard
 
   Whitelist:
     Type: String
@@ -118,7 +134,7 @@ Parameters:
   Memory:
     Type: String
     Description: How much Memory to allocate for the JVM
-    Default: '1G'
+    Default: 1G
 
   Seed:
     Type: String
@@ -136,63 +152,141 @@ Parameters:
 
   GameMode:
     Type: String
-    Description: "Options: creative, survival (default), adventure, spectator (v1.8+)"
+    Description: 'Options: creative, survival (default), adventure, spectator (v1.8+)'
     Default: survival
     AllowedValues:
-    - creative
-    - survival
-    - adventure
-    - spectator
+      - creative
+      - survival
+      - adventure
+      - spectator
 
   LevelType:
     Type: String
-    Description: "Options: DEFAULT, FLAT, LARGEBIOMES, AMPLIFIED, CUSTOMIZED, BUFFET, BIOMESOP (v1.12-), BIOMESOPLENTY (v1.15+)"
+    Description: 'Options: DEFAULT, FLAT, LARGEBIOMES, AMPLIFIED, CUSTOMIZED,
+      BUFFET, BIOMESOP (v1.12-), BIOMESOPLENTY (v1.15+)'
     Default: DEFAULT
     AllowedValues:
-    - DEFAULT
-    - FLAT
-    - LARGEBIOMES
-    - AMPLIFIED
-    - CUSTOMIZED
-    - BUFFET
-    - BIOMESOP
-    - BIOMESOPLENTY
+      - DEFAULT
+      - FLAT
+      - LARGEBIOMES
+      - AMPLIFIED
+      - CUSTOMIZED
+      - BUFFET
+      - BIOMESOP
+      - BIOMESOPLENTY
 
   EnableRollingLogs:
     Type: String
-    Description: "By default the log file will grow without limit. Set to true to use a rolling log strategy."
+    Description: By default the log file will grow without limit. Set to true to use
+      a rolling log strategy.
     Default: false
     AllowedValues:
-    - true
-    - false
+      - true
+      - false
 
   Timezone:
     Type: String
-    Description: "Change the server's timezone. Use the canonical name of the format: Area/Location (e.g. America/New_York)"
+    Description: 'Change the server''s timezone. Use the canonical name of the
+      format: Area/Location (e.g. America/New_York)'
 
 Conditions:
-  MinecraftTypeTagProvided: !Not [ !Equals [ !Ref MinecraftTypeTag, '' ] ]
-  AdminPlayerNamesProvided: !Not [ !Equals [ !Ref AdminPlayerNames, '' ] ]
-  DifficultyProvided: !Not [ !Equals [ !Ref Difficulty, '' ] ]
-  WhitelistProvided: !Not [ !Equals [ !Ref Whitelist, '' ] ]
-  MinecraftVersionProvided: !Not [ !Equals [ !Ref MinecraftVersion, '' ] ]
-  EntryPointProvided: !Not [ !Equals [ !Join [ "", !Ref EntryPoint ], '' ] ]
-  CommandProvided: !Not [ !Equals [ !Join [ "", !Ref Command ], '' ] ]
-  LogGroupNameProvided: !Not [ !Equals [ !Ref LogGroupName, '' ] ]
-  LogStreamPrefixProvided:  !Not [ !Equals [ !Ref LogStreamPrefix, '' ] ]
-  KeyPairNameProvided: !Not [ !Equals [ !Ref KeyPairName, '' ] ]
-  IPv4AddressProvided: !Not [ !Equals [ !Ref YourIPv4, '' ] ]
-  IPv6AddressProvided: !Not [ !Equals [ !Ref YourIPv6, '' ] ]
-  DnsConfigEnabled: !And [ !Not [ !Equals [ !Ref HostedZoneId, '' ] ], !Not [ !Equals [ !Ref RecordName, '' ] ] ]
-  SpotPriceProvided: !Not [ !Equals [ !Ref SpotPrice, '' ] ]
-  MemoryProvided: !Not [ !Equals [ !Ref Memory, '' ] ]
-  SeedProvided: !Not [ !Equals [ !Ref Seed, '' ] ]
-  MaxPlayersProvided: !Not [ !Equals [ !Ref MaxPlayers, -1 ] ]
-  ViewDistanceProvided: !Not [ !Equals [ !Ref ViewDistance, -1 ] ]
-  GameModeProvided: !Not [ !Equals [ !Ref GameMode, '' ] ]
-  LevelTypeProvided: !Not [ !Equals [ !Ref LevelType, '' ] ]
-  EnableRollingLogsProvided: !Not [ !Equals [ !Ref EnableRollingLogs, '' ] ]
-  TimezoneProvided: !Not [ !Equals [ !Ref Timezone, '' ] ]
+  MinecraftTypeTagProvided: !Not
+    - !Equals
+      - !Ref MinecraftTypeTag
+      - ''
+  AdminPlayerNamesProvided: !Not
+    - !Equals
+      - !Ref AdminPlayerNames
+      - ''
+  DifficultyProvided: !Not
+    - !Equals
+      - !Ref Difficulty
+      - ''
+  WhitelistProvided: !Not
+    - !Equals
+      - !Ref Whitelist
+      - ''
+  MinecraftVersionProvided: !Not
+    - !Equals
+      - !Ref MinecraftVersion
+      - ''
+  EntryPointProvided: !Not
+    - !Equals
+      - !Join
+        - ''
+        - !Ref EntryPoint
+      - ''
+  CommandProvided: !Not
+    - !Equals
+      - !Join
+        - ''
+        - !Ref Command
+      - ''
+  LogGroupNameProvided: !Not
+    - !Equals
+      - !Ref LogGroupName
+      - ''
+  LogStreamPrefixProvided: !Not
+    - !Equals
+      - !Ref LogStreamPrefix
+      - ''
+  KeyPairNameProvided: !Not
+    - !Equals
+      - !Ref KeyPairName
+      - ''
+  IPv4AddressProvided: !Not
+    - !Equals
+      - !Ref YourIPv4
+      - ''
+  IPv6AddressProvided: !Not
+    - !Equals
+      - !Ref YourIPv6
+      - ''
+  DnsConfigEnabled: !And
+    - !Not
+      - !Equals
+        - !Ref HostedZoneId
+        - ''
+    - !Not
+      - !Equals
+        - !Ref RecordName
+        - ''
+  SpotPriceProvided: !Not
+    - !Equals
+      - !Ref SpotPrice
+      - ''
+  MemoryProvided: !Not
+    - !Equals
+      - !Ref Memory
+      - ''
+  SeedProvided: !Not
+    - !Equals
+      - !Ref Seed
+      - ''
+  MaxPlayersProvided: !Not
+    - !Equals
+      - !Ref MaxPlayers
+      - -1
+  ViewDistanceProvided: !Not
+    - !Equals
+      - !Ref ViewDistance
+      - -1
+  GameModeProvided: !Not
+    - !Equals
+      - !Ref GameMode
+      - ''
+  LevelTypeProvided: !Not
+    - !Equals
+      - !Ref LevelType
+      - ''
+  EnableRollingLogsProvided: !Not
+    - !Equals
+      - !Ref EnableRollingLogs
+      - ''
+  TimezoneProvided: !Not
+    - !Equals
+      - !Ref Timezone
+      - ''
 
 Mappings:
   ServerState:
@@ -203,9 +297,9 @@ Mappings:
 
 Resources:
   # VPC and related resources
-  Vpc: 
+  Vpc:
     Type: AWS::EC2::VPC
-    Properties: 
+    Properties:
       CidrBlock: 10.100.0.0/26
       EnableDnsSupport: true
       EnableDnsHostnames: true
@@ -214,32 +308,42 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       AvailabilityZone: !Select
-      - 0
-      - !GetAZs 
-        Ref: 'AWS::Region'
-      CidrBlock: !Select [ 0, !Cidr [ 10.100.0.0/26, 4, 4 ] ]
-      VpcId: !Ref Vpc  
+        - 0
+        - !GetAZs
+          Ref: AWS::Region
+      CidrBlock: !Select
+        - 0
+        - !Cidr
+          - 10.100.0.0/26
+          - 4
+          - 4
+      VpcId: !Ref Vpc
 
   SubnetARoute:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties: 
+    Properties:
       RouteTableId: !Ref RouteTable
       SubnetId: !Ref SubnetA
 
   SubnetBRoute:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties: 
+    Properties:
       RouteTableId: !Ref RouteTable
-      SubnetId: !Ref SubnetB  
+      SubnetId: !Ref SubnetB
 
   SubnetB:
     Type: AWS::EC2::Subnet
     Properties:
       AvailabilityZone: !Select
-      - 1
-      - !GetAZs 
-        Ref: 'AWS::Region'
-      CidrBlock: !Select [ 1, !Cidr [ 10.100.0.0/26, 4, 4 ] ]
+        - 1
+        - !GetAZs
+          Ref: AWS::Region
+      CidrBlock: !Select
+        - 1
+        - !Cidr
+          - 10.100.0.0/26
+          - 4
+          - 4
       VpcId: !Ref Vpc
 
   InternetGateway:
@@ -248,18 +352,18 @@ Resources:
 
   InternetGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
-    Properties: 
+    Properties:
       InternetGatewayId: !Ref InternetGateway
       VpcId: !Ref Vpc
 
   RouteTable:
     Type: AWS::EC2::RouteTable
-    Properties: 
-      VpcId: !Ref Vpc    
+    Properties:
+      VpcId: !Ref Vpc
 
   Route:
     Type: AWS::EC2::Route
-    Properties: 
+    Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
       RouteTableId: !Ref RouteTable
@@ -274,7 +378,7 @@ Resources:
     Properties:
       FileSystemId: !Ref Efs
       SecurityGroups:
-      - !Ref EfsSg
+        - !Ref EfsSg
       SubnetId: !Ref SubnetA
 
   MountB:
@@ -282,73 +386,73 @@ Resources:
     Properties:
       FileSystemId: !Ref Efs
       SecurityGroups:
-      - !Ref EfsSg
+        - !Ref EfsSg
       SubnetId: !Ref SubnetB
 
   EfsSg:
     Type: AWS::EC2::SecurityGroup
-    Properties: 
-      GroupName: !Sub "${AWS::StackName}-efs"
-      GroupDescription: !Sub "${AWS::StackName}-efs"
+    Properties:
+      GroupName: !Sub ${AWS::StackName}-efs
+      GroupDescription: !Sub ${AWS::StackName}-efs
       SecurityGroupIngress:
-      - FromPort: 2049
-        ToPort: 2049
-        IpProtocol: tcp
-        SourceSecurityGroupId: !Ref Ec2Sg
+        - FromPort: 2049
+          ToPort: 2049
+          IpProtocol: tcp
+          SourceSecurityGroupId: !Ref Ec2Sg
       VpcId: !Ref Vpc
-      
+
   # INSTANCE CONFIG
   Ec2Sg:
     Type: AWS::EC2::SecurityGroup
-    Properties: 
-      GroupName: !Sub "${AWS::StackName}-ec2"
-      GroupDescription: !Sub "${AWS::StackName}-ec2"
+    Properties:
+      GroupName: !Sub ${AWS::StackName}-ec2
+      GroupDescription: !Sub ${AWS::StackName}-ec2
       SecurityGroupIngress:
-      - !If
-        - IPv4AddressProvided 
-        - FromPort: 22
-          ToPort: 22
+        - !If
+          - IPv4AddressProvided
+          - FromPort: 22
+            ToPort: 22
+            IpProtocol: tcp
+            CidrIp: !Sub ${YourIPv4}/32
+          - !Ref AWS::NoValue
+        - !If
+          - IPv6AddressProvided
+          - FromPort: 22
+            ToPort: 22
+            IpProtocol: tcp
+            CidrIpv6: !Sub ${YourIPv6}/128
+          - !Ref AWS::NoValue
+        - FromPort: 25565
+          ToPort: 25565
           IpProtocol: tcp
-          CidrIp: !Sub "${YourIPv4}/32"
-        - !Ref 'AWS::NoValue'
-      - !If
-        - IPv6AddressProvided 
-        - FromPort: 22
-          ToPort: 22
-          IpProtocol: tcp
-          CidrIpv6: !Sub "${YourIPv6}/128"
-        - !Ref 'AWS::NoValue'
-      - FromPort: 25565
-        ToPort: 25565
-        IpProtocol: tcp
-        CidrIp: 0.0.0.0/0
+          CidrIp: 0.0.0.0/0
       VpcId: !Ref Vpc
 
   InstanceRole:
     Type: AWS::IAM::Role
-    Properties: 
+    Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - ec2.amazonaws.com
-          Action:
-          - sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
-    Properties: 
+    Properties:
       Roles:
         - !Ref InstanceRole
 
   EcsCluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: !Sub "${AWS::StackName}-cluster"
+      ClusterName: !Sub ${AWS::StackName}-cluster
       ClusterSettings:
         - Name: containerInsights
           Value: !Ref ContainerInsights
@@ -356,26 +460,34 @@ Resources:
   LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
-      LaunchTemplateName: !Sub "${AWS::StackName}-launch-template"
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
       LaunchTemplateData:
         IamInstanceProfile:
           Name: !Ref InstanceProfile
         ImageId: !Ref ECSAMI
         InstanceType: !Ref InstanceType
-        KeyName: !If [ KeyPairNameProvided, !Ref KeyPairName, !Ref 'AWS::NoValue' ]
-        InstanceMarketOptions: !If 
+        KeyName: !If
+          - KeyPairNameProvided
+          - !Ref KeyPairName
+          - !Ref AWS::NoValue
+        InstanceMarketOptions: !If
           - SpotPriceProvided
           - MarketType: spot
             SpotOptions:
               MaxPrice: !Ref SpotPrice
-          - !Ref 'AWS::NoValue'
+          - !Ref AWS::NoValue
         NetworkInterfaces:
           - AssociatePublicIpAddress: true
             DeviceIndex: 0
             Groups:
               - !Ref Ec2Sg
-        UserData:
-          Fn::Base64: !Sub |
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Name
+                Value: !Sub ${AWS::StackName}-cluster
+        UserData: !Base64
+          Fn::Sub: |
             #!/bin/bash -xe
             echo ECS_CLUSTER=${EcsCluster} >> /etc/ecs/ecs.config
             yum install -y amazon-efs-utils
@@ -386,11 +498,14 @@ Resources:
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     DependsOn:
-    - MountA
-    - MountB
+      - MountA
+      - MountB
     Properties:
-      AutoScalingGroupName: !Sub "${AWS::StackName}-asg"
-      DesiredCapacity: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
+      AutoScalingGroupName: !Sub ${AWS::StackName}-asg
+      DesiredCapacity: !FindInMap
+        - ServerState
+        - !Ref ServerState
+        - DesiredCapacity
       LaunchTemplate:
         LaunchTemplateId: !Ref LaunchTemplate
         Version: !GetAtt LaunchTemplate.LatestVersionNumber
@@ -401,7 +516,10 @@ Resources:
         - !Ref SubnetA
         - !Ref SubnetB
     Metadata:
-      LaunchEvent: !If [ DnsConfigEnabled, !GetAtt LaunchEvent.Arn, "" ]
+      LaunchEvent: !If
+        - DnsConfigEnabled
+        - !GetAtt LaunchEvent.Arn
+        - ''
 
   ECSCapacityProvider:
     Type: AWS::ECS::CapacityProvider
@@ -427,11 +545,14 @@ Resources:
 
   EcsService:
     Type: AWS::ECS::Service
-    Properties: 
+    Properties:
       Cluster: !Ref EcsCluster
-      DesiredCount: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
-      ServiceName: !Sub "${AWS::StackName}-ecs-service"
-      TaskDefinition: !Ref EcsTask  
+      DesiredCount: !FindInMap
+        - ServerState
+        - !Ref ServerState
+        - DesiredCapacity
+      ServiceName: !Sub ${AWS::StackName}-ecs-service
+      TaskDefinition: !Ref EcsTask
       CapacityProviderStrategy:
         - CapacityProvider: !Ref ECSCapacityProvider
           Weight: 1
@@ -442,153 +563,152 @@ Resources:
 
   EcsTask:
     Type: AWS::ECS::TaskDefinition
-    Properties: 
+    Properties:
       Volumes:
-      - Host:
-          SourcePath: /opt/minecraft
-        Name: minecraft
-      NetworkMode: "bridge"
-      ContainerDefinitions:      
+        - Host:
+            SourcePath: /opt/minecraft
+          Name: minecraft
+      NetworkMode: bridge
+      ContainerDefinitions:
         - Name: minecraft
           MemoryReservation: 1024
-          Image: !Sub "itzg/minecraft-server:${MinecraftImageTag}"
+          Image: !Sub itzg/minecraft-server:${MinecraftImageTag}
           EntryPoint: !If
-              - EntryPointProvided
-              - !Ref EntryPoint
-              - !Ref 'AWS::NoValue'
+            - EntryPointProvided
+            - !Ref EntryPoint
+            - !Ref AWS::NoValue
           Command: !If
-              - CommandProvided
-              - !Ref Command
-              - !Ref 'AWS::NoValue'
+            - CommandProvided
+            - !Ref Command
+            - !Ref AWS::NoValue
           PortMappings:
-          - ContainerPort: 25565
-            HostPort: 25565
-            Protocol: tcp
-          LogConfiguration:
-            !If
+            - ContainerPort: 25565
+              HostPort: 25565
+              Protocol: tcp
+          LogConfiguration: !If
             - LogGroupNameProvided
             - LogDriver: awslogs
               Options:
                 awslogs-group: !Ref CloudWatchLogGroup
                 awslogs-stream-prefix: !If
-                - LogStreamPrefixProvided
-                - !Sub ${LogStreamPrefix}
-                - !Ref 'AWS::NoValue'
+                  - LogStreamPrefixProvided
+                  - !Sub ${LogStreamPrefix}
+                  - !Ref AWS::NoValue
                 awslogs-region: !Ref AWS::Region
                 awslogs-create-group: true
-            - !Ref 'AWS::NoValue'
+            - !Ref AWS::NoValue
           MountPoints:
-          - ContainerPath: /data
-            SourceVolume: minecraft
-            ReadOnly: false
+            - ContainerPath: /data
+              SourceVolume: minecraft
+              ReadOnly: false
           Environment:
-            - Name: "EULA"
-              Value: "TRUE"
+            - Name: EULA
+              Value: 'TRUE'
             - !If
               - MinecraftTypeTagProvided
-              - Name: "TYPE"
-                Value: !Sub "${MinecraftTypeTag}"
-              - !Ref 'AWS::NoValue'
+              - Name: TYPE
+                Value: !Sub ${MinecraftTypeTag}
+              - !Ref AWS::NoValue
             - !If
               - AdminPlayerNamesProvided
-              - Name: "OPS"
-                Value: !Sub "${AdminPlayerNames}"
-              - !Ref 'AWS::NoValue'
+              - Name: OPS
+                Value: !Sub ${AdminPlayerNames}
+              - !Ref AWS::NoValue
             - !If
               - DifficultyProvided
-              - Name: "DIFFICULTY"
-                Value: !Sub "${Difficulty}"
-              - !Ref 'AWS::NoValue'
+              - Name: DIFFICULTY
+                Value: !Sub ${Difficulty}
+              - !Ref AWS::NoValue
             - !If
               - WhitelistProvided
-              - Name: "WHITELIST"
-                Value: !Sub "${Whitelist}"
-              - !Ref 'AWS::NoValue'
+              - Name: WHITELIST
+                Value: !Sub ${Whitelist}
+              - !Ref AWS::NoValue
             - !If
               - MinecraftVersionProvided
-              - Name: "VERSION"
-                Value: !Sub "${MinecraftVersion}"
-              - !Ref 'AWS::NoValue'
+              - Name: VERSION
+                Value: !Sub ${MinecraftVersion}
+              - !Ref AWS::NoValue
             - !If
               - MemoryProvided
-              - Name: "MEMORY"
-                Value: !Sub "${Memory}"
-              - !Ref 'AWS::NoValue'
+              - Name: MEMORY
+                Value: !Sub ${Memory}
+              - !Ref AWS::NoValue
             - !If
               - SeedProvided
-              - Name: "SEED"
-                Value: !Sub "${Seed}"
-              - !Ref 'AWS::NoValue'
+              - Name: SEED
+                Value: !Sub ${Seed}
+              - !Ref AWS::NoValue
             - !If
               - MaxPlayersProvided
-              - Name: "MAX_PLAYERS"
-                Value: !Sub "${MaxPlayers}"
-              - !Ref 'AWS::NoValue'
+              - Name: MAX_PLAYERS
+                Value: !Sub ${MaxPlayers}
+              - !Ref AWS::NoValue
             - !If
               - ViewDistanceProvided
-              - Name: "VIEW_DISTANCE"
-                Value: !Sub "${ViewDistance}"
-              - !Ref 'AWS::NoValue'
+              - Name: VIEW_DISTANCE
+                Value: !Sub ${ViewDistance}
+              - !Ref AWS::NoValue
             - !If
               - GameModeProvided
-              - Name: "MODE"
-                Value: !Sub "${GameMode}"
-              - !Ref 'AWS::NoValue'
+              - Name: MODE
+                Value: !Sub ${GameMode}
+              - !Ref AWS::NoValue
             - !If
               - LevelTypeProvided
-              - Name: "LEVEL_TYPE"
-                Value: !Sub "${LevelType}"
-              - !Ref 'AWS::NoValue'
+              - Name: LEVEL_TYPE
+                Value: !Sub ${LevelType}
+              - !Ref AWS::NoValue
             - !If
               - EnableRollingLogsProvided
-              - Name: "ENABLE_ROLLING_LOGS"
-                Value: !Sub "${EnableRollingLogs}"
-              - !Ref 'AWS::NoValue'
+              - Name: ENABLE_ROLLING_LOGS
+                Value: !Sub ${EnableRollingLogs}
+              - !Ref AWS::NoValue
             - !If
               - TimezoneProvided
-              - Name: "TZ"
-                Value: !Sub "${Timezone}"
-              - !Ref 'AWS::NoValue'
+              - Name: TZ
+                Value: !Sub ${Timezone}
+              - !Ref AWS::NoValue
 
   CloudWatchLogGroup:
     Condition: LogGroupNameProvided
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "${LogGroupName}"
-      RetentionInDays: !Sub "${LogGroupRetentionInDays}"
+      LogGroupName: !Sub ${LogGroupName}
+      RetentionInDays: !Sub ${LogGroupRetentionInDays}
 
   # SET DNS RECORD
   SetDNSRecordLambdaRole:
     Type: AWS::IAM::Role
     Condition: DnsConfigEnabled
-    Properties: 
+    Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-          Action:
-          - sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         - PolicyName: root
-          PolicyDocument: 
-            Version: "2012-10-17"
-            Statement: 
-              - Effect: "Allow"
-                Action: "route53:ChangeResourceRecordSets"
-                Resource: !Sub "arn:aws:route53:::hostedzone/${HostedZoneId}"
-              - Effect: "Allow"
-                Action: "ec2:DescribeInstance*"
-                Resource: "*"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: route53:ChangeResourceRecordSets
+                Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneId}
+              - Effect: Allow
+                Action: ec2:DescribeInstance*
+                Resource: '*'
 
   SetDNSRecordLambda:
-    Type: "AWS::Lambda::Function"
+    Type: AWS::Lambda::Function
     Condition: DnsConfigEnabled
-    Properties: 
+    Properties:
       Environment:
         Variables:
           HostedZoneId: !Ref HostedZoneId
@@ -620,7 +740,7 @@ Resources:
                   ]
               })
       Description: Sets Route 53 DNS Record for Minecraft
-      FunctionName: !Sub "${AWS::StackName}-set-dns"
+      FunctionName: !Sub ${AWS::StackName}-set-dns
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt SetDNSRecordLambdaRole.Arn
@@ -630,25 +750,25 @@ Resources:
   LaunchEvent:
     Type: AWS::Events::Rule
     Condition: DnsConfigEnabled
-    Properties: 
+    Properties:
       EventPattern:
         source:
-        - aws.autoscaling
+          - aws.autoscaling
         detail-type:
-        - EC2 Instance Launch Successful
+          - EC2 Instance Launch Successful
         detail:
           AutoScalingGroupName:
-          - !Sub "${AWS::StackName}-asg"
-      Name: !Sub "${AWS::StackName}-instance-launch"
+            - !Sub ${AWS::StackName}-asg
+      Name: !Sub ${AWS::StackName}-instance-launch
       State: ENABLED
       Targets:
         - Arn: !GetAtt SetDNSRecordLambda.Arn
-          Id: !Sub "${AWS::StackName}-set-dns"
+          Id: !Sub ${AWS::StackName}-set-dns
 
   LaunchEventLambdaPermission:
     Type: AWS::Lambda::Permission
     Condition: DnsConfigEnabled
-    Properties: 
+    Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt SetDNSRecordLambda.Arn
       Principal: events.amazonaws.com
@@ -656,6 +776,6 @@ Resources:
 
 Outputs:
   CheckInstanceIp:
-    Description: To find your Minecraft instance IP address, visit the following link. Click on the instance to find its Public IP address.
-    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:tag:aws:autoscaling:groupName=${AutoScalingGroup};sort=tag:Name"
-
+    Description: To find your Minecraft instance IP address, visit the following
+      link. Click on the instance to find its Public IP address.
+    Value: !Sub https://${AWS::Region}.console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:tag:aws:autoscaling:groupName=${AutoScalingGroup};sort=tag:Name

--- a/cf.yml
+++ b/cf.yml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Minecraft Spot Price Server via Docker / ECS
-Parameters:
 
+Parameters:
   ECSAMI:
     Description: AWS ECS AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
@@ -170,113 +170,6 @@ Parameters:
     Type: String
     Description: "Change the server's timezone. Use the canonical name of the format: Area/Location (e.g. America/New_York)"
 
-Metadata:
-  AWS::CloudFormation::Interface:
-    ParameterGroups:
-      - Label: 
-          default: Essential Configuration
-        Parameters:
-        - ServerState
-        - InstanceType
-        - SpotPrice
-      - Label:
-          default: Server Settings
-        Parameters:
-        - MinecraftImageTag
-      - Label:
-          default: Optional Server Settings
-        Parameters:
-        - MinecraftTypeTag
-        - AdminPlayerNames
-        - Difficulty
-        - Whitelist
-        - MinecraftVersion
-        - Memory
-        - Seed
-        - MaxPlayers
-        - ViewDistance
-        - GameMode
-        - LevelType
-        - EnableRollingLogs
-        - Timezone
-      - Label:
-          default: Optional ECS Cluster and Task Configuration
-        Parameters:
-        - ContainerInsights
-        - EntryPoint
-        - Command
-        - LogGroupName
-        - LogGroupRetentionInDays
-        - LogStreamPrefix
-      - Label: 
-          default: Optional Remote Access (SSH) Configuration
-        Parameters:
-        - KeyPairName
-        - YourIPv4
-        - YourIPv6
-      - Label: 
-          default: Optional DNS Configuration
-        Parameters:
-        - HostedZoneId
-        - RecordName
-    ParameterLabels:
-      ServerState:
-        default: "Update this parameter to shut down / start up your Minecraft server as required to save on cost. Takes a few minutes to take effect."
-      InstanceType:
-        default: "Which instance type? You must make sure this is available in your region! https://aws.amazon.com/ec2/pricing/on-demand/"
-      SpotPrice:
-        default: "Maximum spot price per hour? Leave blank to disable spot pricing."
-      MinecraftImageTag:
-        default: "Which version of Minecraft do you want to launch?"
-      MinecraftTypeTag:
-        default: "Which type of Minecraft do you want to launch?"
-      AdminPlayerNames:
-        default: "A comma delimited list (no spaces) of player names to be admins"
-      Difficulty:
-        default: "Which difficulty?"
-      Whitelist:
-        default: "A comma delimited list (no spaces) of player names"
-      MinecraftVersion:
-        default: "Minecraft version ie 1.16.3"
-      ContainerInsights:
-        default: "ECS Container Insights provide additional container metrics, and supports collection of Prometheus metrics.  Additional AWS charges may apply."
-      EntryPoint:
-        default: "Task/container --entrypoint, comma separated e.g. /bin/bash,-c"
-      Command:
-        default: "Task/container command, comma separated arguments passed to entrypoint"
-      LogGroupName:
-        default: "Create CloudWatch Log Group with this name e.g. /Minecraft or /ecs/minecraft, and direct container logs there"
-      LogGroupRetentionInDays:
-        default: "Number of days to retain CloudWatch logs"
-      LogStreamPrefix:
-        default: "Prefix for container log stream e.g. minecraft-server"
-      KeyPairName:
-        default: "If you wish to access the instance via SSH, select a Key Pair to use. https://console.aws.amazon.com/ec2/v2/home?#KeyPairs:sort=keyName"
-      YourIPv4:
-        default: "If you wish to access the instance via SSH and using IPv4, provide it."
-      YourIPv6:
-        default: "If you wish to access the instance via SSH and using IPv6, provide it."
-      HostedZoneId:
-        default: "If you have a hosted zone in Route 53 and wish to update a DNS record whenever your Minecraft instance starts, supply the hosted zone ID here."
-      RecordName:
-        default: "If you have a hosted zone in Route 53 and wish to set a DNS record whenever your Minecraft instance starts, supply a record name here (e.g. minecraft.mydomain.com)."
-      Memory:
-        default: "If you wish to increase the Java memory-heap limit of 1GB. Format: <size>[g|G|m|M|k|K]"
-      Seed:
-        default: "Seed for world generation"
-      MaxPlayers:
-        default: "Max simultaneous players"
-      ViewDistance:
-        default: "Max view distance"
-      GameMode:
-        default: "The Minecraft game mode"
-      LevelType:
-        default: "Level type for world generation"
-      EnableRollingLogs:
-        default: "Whether to enable rolling logs"
-      Timezone:
-        default: "The server's timezone"
-
 Conditions:
   MinecraftTypeTagProvided: !Not [ !Equals [ !Ref MinecraftTypeTag, '' ] ]
   AdminPlayerNamesProvided: !Not [ !Equals [ !Ref AdminPlayerNames, '' ] ]
@@ -301,7 +194,6 @@ Conditions:
   EnableRollingLogsProvided: !Not [ !Equals [ !Ref EnableRollingLogs, '' ] ]
   TimezoneProvided: !Not [ !Equals [ !Ref Timezone, '' ] ]
 
-
 Mappings:
   ServerState:
     Running:
@@ -310,11 +202,7 @@ Mappings:
       DesiredCapacity: 0
 
 Resources:
-
-  # ====================================================
-  # BASIC VPC
-  # ====================================================
-
+  # VPC and related resources
   Vpc: 
     Type: AWS::EC2::VPC
     Properties: 
@@ -376,10 +264,7 @@ Resources:
       GatewayId: !Ref InternetGateway
       RouteTableId: !Ref RouteTable
 
-  # ====================================================
   # EFS FOR PERSISTENT DATA
-  # ====================================================
-
   Efs:
     Type: AWS::EFS::FileSystem
     Properties: {}
@@ -412,10 +297,7 @@ Resources:
         SourceSecurityGroupId: !Ref Ec2Sg
       VpcId: !Ref Vpc
       
-  # ====================================================
   # INSTANCE CONFIG
-  # ====================================================
-
   Ec2Sg:
     Type: AWS::EC2::SecurityGroup
     Properties: 
@@ -441,45 +323,6 @@ Resources:
         IpProtocol: tcp
         CidrIp: 0.0.0.0/0
       VpcId: !Ref Vpc
-
-  LaunchConfiguration:
-    Type: AWS::AutoScaling::LaunchConfiguration
-    Properties:
-      AssociatePublicIpAddress: true
-      IamInstanceProfile: !Ref InstanceProfile
-      ImageId: !Ref ECSAMI
-      InstanceType: !Ref InstanceType
-      KeyName: 
-        !If [ KeyPairNameProvided, !Ref KeyPairName, !Ref 'AWS::NoValue' ]
-      SecurityGroups:
-      - !Ref Ec2Sg
-      SpotPrice: !If [ SpotPriceProvided, !Ref SpotPrice, !Ref 'AWS::NoValue' ]
-      UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash -xe
-          echo ECS_CLUSTER=${EcsCluster} >> /etc/ecs/ecs.config
-          yum install -y amazon-efs-utils
-          mkdir /opt/minecraft
-          mount -t efs ${Efs}:/ /opt/minecraft
-          chown 845:845 /opt/minecraft
-
-  AutoScalingGroup:
-    Type: AWS::AutoScaling::AutoScalingGroup
-    DependsOn:
-    - MountA
-    - MountB
-    Properties:
-      AutoScalingGroupName: !Sub "${AWS::StackName}-asg"
-      DesiredCapacity: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
-      LaunchConfigurationName: !Ref LaunchConfiguration
-      NewInstancesProtectedFromScaleIn: true
-      MaxSize: 1
-      MinSize: 0
-      VPCZoneIdentifier:
-        - !Ref SubnetA
-        - !Ref SubnetB
-    Metadata:
-      LaunchEvent: !If [ DnsConfigEnabled, !GetAtt LaunchEvent.Arn, "" ]
 
   InstanceRole:
     Type: AWS::IAM::Role
@@ -509,6 +352,56 @@ Resources:
       ClusterSettings:
         - Name: containerInsights
           Value: !Ref ContainerInsights
+
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub "${AWS::StackName}-launch-template"
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Name: !Ref InstanceProfile
+        ImageId: !Ref ECSAMI
+        InstanceType: !Ref InstanceType
+        KeyName: !If [ KeyPairNameProvided, !Ref KeyPairName, !Ref 'AWS::NoValue' ]
+        InstanceMarketOptions: !If 
+          - SpotPriceProvided
+          - MarketType: spot
+            SpotOptions:
+              MaxPrice: !Ref SpotPrice
+          - !Ref 'AWS::NoValue'
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: true
+            DeviceIndex: 0
+            Groups:
+              - !Ref Ec2Sg
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash -xe
+            echo ECS_CLUSTER=${EcsCluster} >> /etc/ecs/ecs.config
+            yum install -y amazon-efs-utils
+            mkdir /opt/minecraft
+            mount -t efs ${Efs}:/ /opt/minecraft
+            chown 845:845 /opt/minecraft
+
+  AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+    - MountA
+    - MountB
+    Properties:
+      AutoScalingGroupName: !Sub "${AWS::StackName}-asg"
+      DesiredCapacity: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
+      NewInstancesProtectedFromScaleIn: true
+      MaxSize: 1
+      MinSize: 0
+      VPCZoneIdentifier:
+        - !Ref SubnetA
+        - !Ref SubnetB
+    Metadata:
+      LaunchEvent: !If [ DnsConfigEnabled, !GetAtt LaunchEvent.Arn, "" ]
 
   ECSCapacityProvider:
     Type: AWS::ECS::CapacityProvider
@@ -664,10 +557,7 @@ Resources:
       LogGroupName: !Sub "${LogGroupName}"
       RetentionInDays: !Sub "${LogGroupRetentionInDays}"
 
-  # ====================================================
   # SET DNS RECORD
-  # ====================================================
-
   SetDNSRecordLambdaRole:
     Type: AWS::IAM::Role
     Condition: DnsConfigEnabled
@@ -768,3 +658,4 @@ Outputs:
   CheckInstanceIp:
     Description: To find your Minecraft instance IP address, visit the following link. Click on the instance to find its Public IP address.
     Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:tag:aws:autoscaling:groupName=${AutoScalingGroup};sort=tag:Name"
+

--- a/cf.yml
+++ b/cf.yml
@@ -5,7 +5,7 @@ Parameters:
   ECSAMI:
     Description: AWS ECS AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+    Default: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
   ServerState:
     Type: String

--- a/cf.yml
+++ b/cf.yml
@@ -2,6 +2,13 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Minecraft Spot Price Server via Docker / ECS
 
 Parameters:
+  DaysToBackup:
+    Type: Number
+    Description: Number of days to retain EFS backups (0 disables backups, 1-30 enables backups with specified retention)
+    Default: 0
+    MinValue: 0
+    MaxValue: 30
+
   ECSAMI:
     Description: AWS ECS AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
@@ -288,6 +295,11 @@ Conditions:
       - !Ref Timezone
       - ''
 
+  BackupsEnabled: !Not
+    - !Equals
+      - !Ref DaysToBackup
+      - 0
+
 Mappings:
   ServerState:
     Running:
@@ -371,7 +383,61 @@ Resources:
   # EFS FOR PERSISTENT DATA
   Efs:
     Type: AWS::EFS::FileSystem
-    Properties: {}
+    Properties:
+      BackupPolicy:
+        Status: !If
+          - BackupsEnabled
+          - ENABLED
+          - DISABLED
+
+  # AWS BACKUP RESOURCES
+  BackupVault:
+    Type: AWS::Backup::BackupVault
+    Condition: BackupsEnabled
+    Properties:
+      BackupVaultName: !Sub ${AWS::StackName}-backup-vault
+
+  BackupRole:
+    Type: AWS::IAM::Role
+    Condition: BackupsEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - backup.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup
+
+  BackupPlan:
+    Type: AWS::Backup::BackupPlan
+    Condition: BackupsEnabled
+    Properties:
+      BackupPlan:
+        BackupPlanName: !Sub ${AWS::StackName}-backup-plan
+        BackupPlanRule:
+          - RuleName: !Sub ${AWS::StackName}-daily-backup
+            TargetBackupVault: !Ref BackupVault
+            ScheduleExpression: cron(0 0 ? * * *)  # Daily at midnight UTC
+            StartWindowMinutes: 60
+            CompletionWindowMinutes: 120
+            Lifecycle:
+              DeleteAfterDays: !Ref DaysToBackup
+
+  BackupSelection:
+    Type: AWS::Backup::BackupSelection
+    Condition: BackupsEnabled
+    Properties:
+      BackupPlanId: !Ref BackupPlan
+      BackupSelection:
+        SelectionName: !Sub ${AWS::StackName}-backup-selection
+        IamRoleArn: !GetAtt BackupRole.Arn
+        Resources:
+          - !Sub arn:aws:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:file-system/${Efs}
 
   MountA:
     Type: AWS::EFS::MountTarget

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ This is an updated fork of the original minecraft-spot-pricing project. The orig
 - Updated CloudFormation templates for current AWS services
 - Security improvements and best practices
 - Bug fixes and performance optimizations
+- Automatic backups
 - Updated documentation
 
 ## Prerequisites

--- a/readme.md
+++ b/readme.md
@@ -2,10 +2,18 @@
 
 The template contained within this repository can be used to deploy a Minecraft server to Amazon Web Services (AWS) in minutes. As the solution leverages "Spot Pricing", the server should cost less than a cent an hour to run, and you can even turn it off when you and your friends aren't playing - saving even more money.
 
+## 🔄 Fork Status
+
+This is an updated fork of the original minecraft-spot-pricing project. The original repository has not been maintained for some time, so this fork includes:
+- Updated CloudFormation templates for current AWS services
+- Security improvements and best practices
+- Bug fixes and performance optimizations
+- Updated documentation
+
 ## Prerequisites
 
 1. A basic understanding of Amazon Web Services, specifically CloudFormation.
-2. An AWS Account.
+2. An AWS Account. (checkout https://aws.amazon.com/free)
 3. Basic knowledge of Linux administration (no more than what would be required to just use the `itzg/docker-minecraft-server` Docker image).
 
 ## Overview
@@ -22,7 +30,7 @@ A few notes on the services we're using...
 
 * **EFS** - Elastic File System is used to store Minecraft config, save games, mods etc. None of this is stored on the server itself, as it may terminate at any time.
 * **Auto Scaling** - An Auto Scaling Group is used to maintain a single instance via spot pricing.
-* **VPC** - The template deploys a very basic VPC, purely for use by the Minecraft server. This doesn't cost you a cent.
+* **VPC** - The template deploys a very basic VPC, purely for use by the Minecraft server. 
 
 ## Getting Started
 
@@ -31,7 +39,7 @@ A few notes on the services we're using...
 1. Click the above link, you'll need to log into your AWS account if you haven't already.
 2. Ensure you've selected a suitable AWS Region (closest to you) via the selector at the top right.
 3. Upload the cf.yml file.
-4. Click Next to proceed through the CloudFormation deployment, provide parameters on the following page. You'll need a Key Pair and your Public IP address if you want to access the instance remotely via SSH (recommended). Refer to the Remote Access section below. There should be no need to touch any other parameters unless you have reason to do so. Continue through the rest of the deployment. 
+4. Click Next to proceed through the CloudFormation deployment, provide parameters on the following page. You'll need a Key Pair and your Public IP address if you want to access the instance remotely via SSH (I'm working a a Session Manager update). Refer to the Remote Access section below. There should be no need to touch any other parameters unless you have reason to do so. Continue through the rest of the deployment. 
 
 ## Next Steps
 
@@ -55,6 +63,17 @@ If you're creating a new Minecraft deployment, provide these parameters when cre
 ### Custom Domain Name
 
 Every time your Minecraft server starts it'll have a new public IP address. This can be a pain to keep dishing out to your friends. If you're prepared to register a domain name (maybe you've already got one) and create a Route 53 hosted zone, this problem is easily fixed. You'll need to provide both of the parameters under the DNS Configuration (Optional) section. Whenever your instance is launched, a Lambda function fires off and creates / updates the record of your choosing. This way, you can have a custom domain name such as "minecraft.mydomain.com". Note that it may take a few minutes for the new IP to propagate to your friends computers. Have patience. Failing that just go to the EC2 console, and give them the new public IP address of your instance.
+
+## 🔒 Security Best Practices
+
+- Always use the latest AMI images
+- Regularly update the Docker image version
+- Consider using AWS Systems Manager Session Manager instead of SSH
+- Enable CloudTrail logging for audit purposes
+- Use least-privilege IAM roles
+- Restrict SSH access to known IP addresses only
+- Keep security groups minimal and specific
+- Monitor CloudWatch logs for suspicious activity
 
 ## FAQ
 
@@ -107,6 +126,15 @@ Your public IP address has probably changed. [Check your public IP address]((htt
 ## What's Missing / Not Supported?
 
 * I didn't exhaustively copy over all the environment variables available, feel free to edit the cf.yml as needed by copying and renaming the appropriate blocks (like 'Whitelist/WhitelistProvided')
+
+## 💾 Backup & Recovery
+
+- EFS automatically provides durability across multiple Availability Zones
+- Consider enabling EFS backup for point-in-time recovery
+- World saves are stored in `/opt/minecraft/` on the EFS mount
+- Server configuration files are preserved between instance terminations
+- For additional protection, consider periodic EFS snapshots
+- Document your mod configurations and server settings for easy restoration
 
 ## Expected Costs
 

--- a/readme.md
+++ b/readme.md
@@ -129,12 +129,28 @@ Your public IP address has probably changed. [Check your public IP address]((htt
 
 ## 💾 Backup & Recovery
 
-- EFS automatically provides durability across multiple Availability Zones
-- Consider enabling EFS backup for point-in-time recovery
 - World saves are stored in `/opt/minecraft/` on the EFS mount
 - Server configuration files are preserved between instance terminations
-- For additional protection, consider periodic EFS snapshots
-- Document your mod configurations and server settings for easy restoration
+
+The solution includes built-in backup capabilities using AWS Backup:
+
+- EFS automatically provides durability across multiple Availability Zones
+- AWS Backup integration is available through the `DaysToBackup` parameter:
+  - Set to 0 to disable automated backups
+  - Set between 1-30 to enable daily backups with specified retention period
+- When enabled, the following backup resources are created:
+  - A dedicated backup vault for storing your backups
+  - A daily backup plan with configurable retention
+  - IAM roles with necessary backup permissions
+- All backups are managed through AWS Backup service for:
+  - Point-in-time recovery capabilities
+  - Automated backup scheduling
+  - Consistent backup state
+- Best practices:
+  - Enable backups by setting an appropriate retention period
+  - Document your mod configurations and server settings
+  - Monitor backup completion status in AWS Backup console
+  - Test restore procedures periodically
 
 ## Expected Costs
 


### PR DESCRIPTION
Migrated from launch configuration to launch template

- AWS launch configurations are deprecated as of Dec 2022
- Launch templates offer enhanced features and better spot pricing support
- Maintains backward compatibility while future-proofing the deployment
- Improves instance type flexibility and configuration management
